### PR TITLE
Fix synopsis

### DIFF
--- a/lib/AnyEvent/SlackRTM.pm
+++ b/lib/AnyEvent/SlackRTM.pm
@@ -17,32 +17,36 @@ our $START_URL = 'https://slack.com/api/rtm.start';
 
     use AnyEvent;
     use AnyEvent::SlackRTM;
-    
+
+    my $access_token = "<user or bot token>";
+    my $channel_id = "<channel/group/DM id>";
+
     my $cond = AnyEvent->condvar;
     my $rtm = AnyEvent::SlackRTM->new($access_token);
 
-    my $c = 1;
+    my $i = 1;
     my $keep_alive;
     my $counter;
     $rtm->on('hello' => sub { 
         print "Ready\n";
 
         $keep_alive = AnyEvent->timer(interval => 60, cb => sub {
+            print "Ping\n";
             $rtm->ping;
         });
 
         $counter = AnyEvent->timer(interval => 5, cb => sub {
+            print "Send\n";
             $rtm->send({
                 type => 'message',
-                text => $i++, 
+                channel => $channel_id,
+                text => "".$i++, 
             });
         });
     });
     $rtm->on('message' => sub { 
         my ($rtm, $message) = @_;
-        if ($message->{ok}) {
-            print "> ", $message->{text};
-        }
+        print "> $message->{text}\n";
     });
     $rtm->on('finish' => sub { 
         print "Done\n";


### PR DESCRIPTION
Synopsis wasn't quite right in a couple of places. A few fixes for the next person :smiley:
- Try to make it clear that a channel/group/DM id is needed to send a message.
- Message event doesn't have an "ok" attribute, so don't look for one.
- Use `$i` instead of `$c` for the count var.
- Stringify count var before sending. JSON will serialise a scalar that hasn't been used as a string (an IV) as a JSON number, but the send method is expecting a string. Stringify first to do the right thing.

Great module, thanks :+1:
