### PR TITLE
Remove dependency on AIO

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -9,10 +9,6 @@ license  = Perl_5
 
 [AutoPrereqs]
 
-[Prereqs]
-IO::AIO = 0
-AnyEvent::AIO = 0
-
 [AutoVersion]
 major = 0
 


### PR DESCRIPTION
It's not actually required that I can see; this seems to run fine on top of EV.

(AnyEvent::AIO isn't currently installable in my environment for other reasons, so this dependency is making my life hard!)
