### PR TITLE
add IO::Socket::SSL prereqs

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -9,6 +9,9 @@ license  = Perl_5
 
 [AutoPrereqs]
 
+[Prereqs]
+IO::Socket::SSL = 0
+
 [AutoVersion]
 major = 0
 


### PR DESCRIPTION
Slack url is https://slack.com/api/rtm.start, so we need IO::Socket::SSL!
