### PR TITLE
Die gracefully when we can't connect to Slack

### DIFF
--- a/lib/AnyEvent/SlackRTM.pm
+++ b/lib/AnyEvent/SlackRTM.pm
@@ -123,6 +123,8 @@ sub start {
     );
 
     my $res = $furl->get($START_URL . '?token=' . $self->{token});
+    croak "unable to start, Slack call failed: $res->{code} $res->{message}"
+        unless $res->{code} =~ m/^2/;
     my $start = decode_json($res->content);
 
     my $ok  = $start->{ok};


### PR DESCRIPTION
Changes something like this:

``` perl
malformed JSON string, neither tag, array, object, number, string or atom, at character offset 0 (before "Cannot resolve host ...") at /home/robn/perl5/perlbrew/perls/perl/5.20.0/lib/site_perl/5.20.2/AnyEvent/SlackRTM.pm line 41.
```

Into something like this:

``` perl
unable to start, Slack call failed: 500 Internal Response: Cannot create SSL connection: SSL wants a read first at ../perl/AnyEvent-SlackRTM/lib/AnyEvent/SlackRTM.pm line 125.
 at lib/Bort.pm line 121.
```

Which isn't a huge improvement, but at least it's more clear that it's a connection problem instead of a JSON error.
