### PR TITLE
add timeout option to Furl

### DIFF
--- a/lib/AnyEvent/SlackRTM.pm
+++ b/lib/AnyEvent/SlackRTM.pm
@@ -127,7 +127,8 @@ sub start {
     $VERSION //= '*-devel';
 
     my $furl = Furl->new(
-        agent => "AnyEvent::SlackRTM/$VERSION",
+        agent   => "AnyEvent::SlackRTM/$VERSION",
+        timeout => $self->{client}->timeout,
     );
 
     my $res = $furl->get($START_URL . '?token=' . $self->{token});


### PR DESCRIPTION
Added timeout option to furl because when `https://slack.com/api/rtm.start` response is too big, a timeout causes.

In [AnyEvent::WebSocket::Client](https://metacpan.org/pod/AnyEvent::WebSocket::Client#timeout), default timeout is 30, but [Furl' default timeout](https://metacpan.org/module/Furl::HTTP/source#L59) is 10, which makes AnyEvent::WebSocket::Client's timeout less meaningful.
So I modified it so that AnyEvent::WebSocket::Client's timeout is also set to Furl's timeout.