### PR TITLE
Pass env_proxy opts to Furl

### DIFF
--- a/lib/AnyEvent/SlackRTM.pm
+++ b/lib/AnyEvent/SlackRTM.pm
@@ -5,7 +5,7 @@ use v5.14;
 # ABSTRACT: AnyEvent module for interacting with the Slack RTM API
 
 use AnyEvent;
-use AnyEvent::WebSocket::Client 0.12;
+use AnyEvent::WebSocket::Client 0.46;
 use Carp;
 use Furl;
 use JSON;
@@ -87,6 +87,8 @@ L<Bot Token|https://slack.com/services/new/bot>. If you configure a bot integrat
 =back
 
 The C<$client_opts> is an optional HashRef of L<AnyEvent::WebSocket::Client>'s configuration options, e.g. C<env_proxy>, C<max_payload_size>, C<timeout>, etc.
+If the C<env_proxy> option is passed,
+it is also used on the L<Furl> client used internally.
 
 =cut
 
@@ -104,9 +106,10 @@ sub new {
     };
 
     return bless {
-        token    => $token,
-        client   => $client,
-        registry => {},
+        token       => $token,
+        client      => $client,
+        client_opts => $client_opts,
+        registry    => {},
     }, $class;
 }
 
@@ -130,6 +133,7 @@ sub start {
         agent   => "AnyEvent::SlackRTM/$VERSION",
         timeout => $self->{client}->timeout,
     );
+    $furl->env_proxy if $self->{client_opts}->{env_proxy};
 
     my $res = $furl->get($START_URL . '?token=' . $self->{token});
     my $start = try {

--- a/t/06-env_proxy.t
+++ b/t/06-env_proxy.t
@@ -1,0 +1,40 @@
+#!/usr/bin/env perl
+use v5.14;
+use warnings;
+
+use Test::More;
+use AnyEvent::SlackRTM;
+use Furl;
+
+$ENV{http_proxy} = "https://aesrtm.test";
+my $furl_env_proxy_set = 0;
+
+no warnings qw< redefine >;
+local *Furl::get = sub {
+    $furl_env_proxy_set = ${ $_[0] }->{proxy} eq 'https://aesrtm.test';
+    die 'Skipped the get';
+};
+use warnings qw< redefine >;
+
+my $token = 'fake';
+{
+    $furl_env_proxy_set = undef;
+    my $rtm = AnyEvent::SlackRTM->new($token);
+    ok !$rtm->{client}->env_proxy, "No proxy on the websocket client";
+
+    eval { $rtm->start };
+    like $@, qr/^Skipped the get /, "Didn't actually make a request";
+    ok !$furl_env_proxy_set, "Furl did not get proxy settings from %ENV";
+}
+
+{
+    $furl_env_proxy_set = undef;
+    my $rtm = AnyEvent::SlackRTM->new( $token, { env_proxy => 1 } );
+    ok $rtm->{client}->env_proxy, "Set the env_proxy from the passed in opt";
+
+    eval { $rtm->start };
+    like $@, qr/^Skipped the get /, "Didn't actually make a request";
+    ok $furl_env_proxy_set, "Furl got proxy settings from %ENV";
+}
+
+done_testing();


### PR DESCRIPTION
This could use better tests, but I couldn't figure out how to have an AnyEvent::Socket listening during $rtm->start.

This should resolve #10 by calling env_proxy if that was one of the opts passed to the constructor.  It didn't seem worthwhile to have separate options for both of these.

This does pull in the newer AnyEvent::WebSocket::Client that has support for env_proxy as well, but that was mostly needed to make sure the tests passed.